### PR TITLE
Bump to .NET 10, switch to Scalar, harden Hangfire SQLite

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['7.0']
+        dotnet-version: ['10.0']
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 WORKDIR /app
 
 # Copy everything
@@ -9,7 +9,7 @@ RUN dotnet restore --use-current-runtime
 RUN dotnet publish -c Release -o out --use-current-runtime --self-contained false --no-restore
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENV ASPNETCORE_URLS=http://+:31099
 WORKDIR /app

--- a/src/PlexNotifierr.Api/Controllers/SubscribeManagement.cs
+++ b/src/PlexNotifierr.Api/Controllers/SubscribeManagement.cs
@@ -2,54 +2,53 @@ using Microsoft.AspNetCore.Mvc;
 using PlexNotifierr.Core.Models;
 using PlexNotifierr.Api.Models;
 
-namespace PlexNotifierr.Controllers
+namespace PlexNotifierr.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class SubscribeManagement : ControllerBase
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class SubscribeManagement : ControllerBase
+    private readonly ILogger<SubscribeManagement> _logger;
+    private readonly PlexNotifierrDbContext _dbContext;
+
+    public SubscribeManagement(PlexNotifierrDbContext dbContext, ILogger<SubscribeManagement> logger)
     {
-        private readonly ILogger<SubscribeManagement> _logger;
-        private readonly PlexNotifierrDbContext _dbContext;
+        _logger = logger;
+        _dbContext = dbContext;
+    }
 
-        public SubscribeManagement(PlexNotifierrDbContext dbContext, ILogger<SubscribeManagement> logger)
+    [HttpPost("/subscription")]
+    public async Task<IActionResult> Subscribe([FromBody] SubscribeRequest req)
+    {
+        var user = _dbContext.Users.FirstOrDefault(user => user.DiscordId == req.DiscordId);
+        if (user is null)
         {
-            _logger = logger;
-            _dbContext = dbContext;
-        }
-
-        [HttpPost("/subscription")]
-        public async Task<IActionResult> Subscribe([FromBody] SubscribeRequest req)
-        {
-            var user = _dbContext.Users.FirstOrDefault(user => user.DiscordId == req.DiscordId);
-            if (user is null)
+            if (req.PlexName is null)
             {
-                if (req.PlexName is null)
-                {
-                    return NotFound();
-                }
-                user = _dbContext.Users.FirstOrDefault(user => user.PlexName == req.PlexName);
-                if (user is null)
-                {
-                    return NotFound();
-                }
-                user.DiscordId = req.DiscordId;
+                return NotFound();
             }
-            user.Active = true;
-            await _dbContext.SaveChangesAsync();
-            return Ok();
-        }
-
-        [HttpDelete("/subscription")]
-        public async Task<IActionResult> Unsubscribe([FromBody] UnsubscribeRequest req)
-        {
-            var user = _dbContext.Users.FirstOrDefault(user => user.DiscordId == req.DiscordId);
+            user = _dbContext.Users.FirstOrDefault(user => user.PlexName == req.PlexName);
             if (user is null)
             {
                 return NotFound();
             }
-            user.Active = false;
-            await _dbContext.SaveChangesAsync();
-            return Ok();
+            user.DiscordId = req.DiscordId;
         }
+        user.Active = true;
+        await _dbContext.SaveChangesAsync();
+        return Ok();
+    }
+
+    [HttpDelete("/subscription")]
+    public async Task<IActionResult> Unsubscribe([FromBody] UnsubscribeRequest req)
+    {
+        var user = _dbContext.Users.FirstOrDefault(user => user.DiscordId == req.DiscordId);
+        if (user is null)
+        {
+            return NotFound();
+        }
+        user.Active = false;
+        await _dbContext.SaveChangesAsync();
+        return Ok();
     }
 }

--- a/src/PlexNotifierr.Api/Extensions/HangfireExtensions.cs
+++ b/src/PlexNotifierr.Api/Extensions/HangfireExtensions.cs
@@ -5,69 +5,139 @@ using Hangfire.Dashboard;
 using Hangfire.Heartbeat;
 using Hangfire.Heartbeat.Server;
 using Hangfire.Storage.SQLite;
+using Microsoft.Data.Sqlite;
 using PlexNotifierr.Api.Hangfire;
 using PlexNotifierr.Worker.Jobs;
+using Serilog;
 
-namespace PlexNotifierr.Api.Extensions
+namespace PlexNotifierr.Api.Extensions;
+
+public class HangfireExtensions
 {
-    public class HangfireExtensions
+    public static void AddHangfire(IServiceCollection services, IConfiguration configuration)
     {
-        public static void AddHangfire(IServiceCollection services, IConfiguration configuration)
+        var connectionStringHangfire = configuration.GetConnectionString("Hangfire");
+        EnsureHangfireStorageIsHealthy(connectionStringHangfire);
+        services.AddHangfire(options =>
         {
-            var connectionStringHangfire = configuration.GetConnectionString("Hangfire");
-            services.AddHangfire(options =>
+            options.UseSQLiteStorage(connectionStringHangfire)
+                   .WithJobExpirationTimeout(TimeSpan.FromDays(30))
+                   .UseDashboardMetric(DashboardMetrics.ServerCount)
+                   .UseDashboardMetric(DashboardMetrics.RecurringJobCount)
+                   .UseDashboardMetric(DashboardMetrics.RetriesCount)
+                   .UseDashboardMetric(DashboardMetrics.EnqueuedCountOrNull)
+                   .UseDashboardMetric(DashboardMetrics.FailedCountOrNull)
+                   .UseDashboardMetric(DashboardMetrics.EnqueuedAndQueueCount)
+                   .UseDashboardMetric(DashboardMetrics.ScheduledCount)
+                   .UseDashboardMetric(DashboardMetrics.ProcessingCount)
+                   .UseDashboardMetric(DashboardMetrics.SucceededCount)
+                   .UseDashboardMetric(DashboardMetrics.FailedCount)
+                   .UseDashboardMetric(DashboardMetrics.DeletedCount)
+                   .UseDashboardMetric(DashboardMetrics.AwaitingCount)
+                   .UseHeartbeatPage(TimeSpan.FromSeconds(5))
+                   .UseConsole();
+        });
+    }
+
+    public static void AddHangfireServer(IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionStringHangfire = configuration.GetConnectionString("Hangfire");
+        services.AddHangfireServer((_, options) =>
+        {
+            options.Queues = new[] { "default" };
+            options.ServerName = "WORKER-" + Environment.MachineName;
+            options.WorkerCount = 1;
+        }, new SQLiteStorage(connectionStringHangfire), new[] { new ProcessMonitor(checkInterval: TimeSpan.FromSeconds(5)) });
+    }
+
+    public static void AddHangfireConsoleExtensions(IServiceCollection services)
+    {
+        services.AddHangfireConsoleExtensions();
+    }
+
+    public static void ConfigureHangfireDashboard(WebApplication app)
+    {
+        app.UseHangfireDashboard("/dashboard",options: new DashboardOptions
+        {
+            Authorization = new[] { new NoAuthorizationFilter() },
+            DashboardTitle = "Notifierr Dashboard",
+            DisplayStorageConnectionString = true,
+            AppPath = null
+        });
+    }
+
+    public static void ConfigureRecurringJob()
+    {
+        RecurringJob.AddOrUpdate<GetUsersJob>(x => x.ExecuteAsync(), Cron.Daily);
+        RecurringJob.AddOrUpdate<GetUsersHistoryJob>(x => x.ExecuteAsync(), Cron.Hourly);
+        RecurringJob.AddOrUpdate<GetRecentlyAddedJob>(x => x.ExecuteAsync(), Cron.Minutely);
+    }
+
+    // The Hangfire.Storage.SQLite database occasionally corrupts ("database disk image is malformed"),
+    // which leaks an endless stream of errors from the distributed-lock cleanup loop. Hangfire jobs are
+    // transient state (queues + recurring schedules), so on corruption we drop the file and let Hangfire
+    // recreate the schema on startup rather than ship with a broken store.
+    private static void EnsureHangfireStorageIsHealthy(string? connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString)) return;
+
+        var dbPath = ResolveSqliteFilePath(connectionString);
+        if (dbPath is null || !File.Exists(dbPath)) return;
+
+        if (IsSqliteDatabaseHealthy(dbPath)) return;
+
+        Log.Warning("Hangfire SQLite database at {DbPath} is corrupt; resetting it", dbPath);
+        DeleteSqliteDatabaseFiles(dbPath);
+    }
+
+    private static string? ResolveSqliteFilePath(string connectionString)
+    {
+        // Hangfire.Storage.SQLite accepts either a raw file path or a Microsoft.Data.Sqlite-style
+        // connection string ("Data Source=...").
+        if (!connectionString.Contains('=', StringComparison.Ordinal))
+            return Path.GetFullPath(connectionString);
+
+        try
+        {
+            return Path.GetFullPath(new SqliteConnectionStringBuilder(connectionString).DataSource);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsSqliteDatabaseHealthy(string dbPath)
+    {
+        try
+        {
+            using var connection = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");
+            connection.Open();
+            using var command = connection.CreateCommand();
+            command.CommandText = "PRAGMA integrity_check;";
+            using var reader = command.ExecuteReader();
+            return reader.Read() && string.Equals(reader.GetString(0), "ok", StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Hangfire SQLite integrity check failed for {DbPath}", dbPath);
+            return false;
+        }
+    }
+
+    private static void DeleteSqliteDatabaseFiles(string dbPath)
+    {
+        foreach (var suffix in new[] { "", "-shm", "-wal", "-journal" })
+        {
+            var path = dbPath + suffix;
+            try
             {
-                options.UseSQLiteStorage(connectionStringHangfire)
-                       .WithJobExpirationTimeout(TimeSpan.FromDays(30))
-                       .UseDashboardMetric(DashboardMetrics.ServerCount)
-                       .UseDashboardMetric(DashboardMetrics.RecurringJobCount)
-                       .UseDashboardMetric(DashboardMetrics.RetriesCount)
-                       .UseDashboardMetric(DashboardMetrics.EnqueuedCountOrNull)
-                       .UseDashboardMetric(DashboardMetrics.FailedCountOrNull)
-                       .UseDashboardMetric(DashboardMetrics.EnqueuedAndQueueCount)
-                       .UseDashboardMetric(DashboardMetrics.ScheduledCount)
-                       .UseDashboardMetric(DashboardMetrics.ProcessingCount)
-                       .UseDashboardMetric(DashboardMetrics.SucceededCount)
-                       .UseDashboardMetric(DashboardMetrics.FailedCount)
-                       .UseDashboardMetric(DashboardMetrics.DeletedCount)
-                       .UseDashboardMetric(DashboardMetrics.AwaitingCount)
-                       .UseHeartbeatPage(TimeSpan.FromSeconds(5))
-                       .UseConsole();
-            });
-        }
-
-        public static void AddHangfireServer(IServiceCollection services, IConfiguration configuration)
-        {
-            var connectionStringHangfire = configuration.GetConnectionString("Hangfire");
-            services.AddHangfireServer((_, options) =>
+                if (File.Exists(path)) File.Delete(path);
+            }
+            catch (Exception e)
             {
-                options.Queues = new[] { "default" };
-                options.ServerName = "WORKER-" + Environment.MachineName;
-                options.WorkerCount = 1;
-            }, new SQLiteStorage(connectionStringHangfire), new[] { new ProcessMonitor(checkInterval: TimeSpan.FromSeconds(5)) });
-        }
-
-        public static void AddHangfireConsoleExtensions(IServiceCollection services)
-        {
-            services.AddHangfireConsoleExtensions();
-        }
-
-        public static void ConfigureHangfireDashboard(WebApplication app)
-        {
-            app.UseHangfireDashboard("/dashboard",options: new DashboardOptions
-            {
-                Authorization = new[] { new NoAuthorizationFilter() },
-                DashboardTitle = "Notifierr Dashboard",
-                DisplayStorageConnectionString = true,
-                AppPath = null
-            });
-        }
-
-        public static void ConfigureRecurringJob()
-        {
-            RecurringJob.AddOrUpdate<GetUsersJob>(x => x.ExecuteAsync(), Cron.Daily);
-            RecurringJob.AddOrUpdate<GetUsersHistoryJob>(x => x.ExecuteAsync(), Cron.Hourly);
-            RecurringJob.AddOrUpdate<GetRecentlyAddedJob>(x => x.ExecuteAsync(), Cron.Minutely);
+                Log.Error(e, "Failed to delete Hangfire SQLite artifact {Path}", path);
+            }
         }
     }
 }

--- a/src/PlexNotifierr.Api/Extensions/PlexExtensions.cs
+++ b/src/PlexNotifierr.Api/Extensions/PlexExtensions.cs
@@ -8,29 +8,28 @@ using PlexNotifierr.Core.Config;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-namespace PlexNotifierr.Api.Extensions
+namespace PlexNotifierr.Api.Extensions;
+
+public static class PlexExtensions
 {
-    public static class PlexExtensions
+    public static void AddPlexApi(IServiceCollection services, IConfigurationRoot configuration)
     {
-        public static void AddPlexApi(IServiceCollection services, IConfigurationRoot configuration)
+        _ = services.Configure<PlexConfig>(configuration.GetSection("Plex"));
+        var plexConfig = configuration.GetSection("Plex").Get<PlexConfig>();
+        var apiOptions = new ClientOptions
         {
-            _ = services.Configure<PlexConfig>(configuration.GetSection("Plex"));
-            var plexConfig = configuration.GetSection("Plex").Get<PlexConfig>();
-            var apiOptions = new ClientOptions
-            {
-                Product = plexConfig.Product,
-                DeviceName = plexConfig.DeviceName,
-                ClientId = plexConfig.ClientId,
-                Platform = RuntimeInformation.OSDescription,
-                Version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyVersionAttribute>()?.Version ?? "v0"
-            };
-            services.AddSingleton(apiOptions)
-                    .AddTransient<IPlexServerClient, PlexServerClient>()
-                    .AddTransient<IPlexAccountClient, PlexAccountClient>()
-                    .AddTransient<IPlexLibraryClient, PlexLibraryClient>()
-                    .AddTransient<IApiService, ApiService>()
-                    .AddTransient<IPlexFactory, PlexFactory>()
-                    .AddTransient<IPlexRequestsHttpClient, PlexRequestsHttpClient>();
-        }
+            Product = plexConfig.Product,
+            DeviceName = plexConfig.DeviceName,
+            ClientId = plexConfig.ClientId,
+            Platform = RuntimeInformation.OSDescription,
+            Version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyVersionAttribute>()?.Version ?? "v0"
+        };
+        services.AddSingleton(apiOptions)
+                .AddTransient<IPlexServerClient, PlexServerClient>()
+                .AddTransient<IPlexAccountClient, PlexAccountClient>()
+                .AddTransient<IPlexLibraryClient, PlexLibraryClient>()
+                .AddTransient<IApiService, ApiService>()
+                .AddTransient<IPlexFactory, PlexFactory>()
+                .AddTransient<IPlexRequestsHttpClient, PlexRequestsHttpClient>();
     }
 }

--- a/src/PlexNotifierr.Api/Extensions/PublicationExtensions.cs
+++ b/src/PlexNotifierr.Api/Extensions/PublicationExtensions.cs
@@ -1,13 +1,12 @@
 using PlexNotifierr.Core.Messaging;
 
-namespace PlexNotifierr.Api.Extensions
+namespace PlexNotifierr.Api.Extensions;
+
+public static class PublicationExtensions
 {
-    public static class PublicationExtensions
+    public static void AddRabbitMqSender(IServiceCollection services, IConfiguration configuration)
     {
-        public static void AddRabbitMqSender(IServiceCollection services, IConfiguration configuration)
-        {
-            services.AddOptions<RabbitMqConfig>().Bind(configuration.GetSection("RabbitMQ"));
-            services.AddSingleton<INotificationSender, NotificationSender>();
-        }
+        services.AddOptions<RabbitMqConfig>().Bind(configuration.GetSection("RabbitMQ"));
+        services.AddSingleton<INotificationSender, NotificationSender>();
     }
 }

--- a/src/PlexNotifierr.Api/Models/SubscribeRequest.cs
+++ b/src/PlexNotifierr.Api/Models/SubscribeRequest.cs
@@ -1,8 +1,7 @@
-namespace PlexNotifierr.Api.Models
+namespace PlexNotifierr.Api.Models;
+
+public class SubscribeRequest
 {
-    public class SubscribeRequest
-    {
-        public string DiscordId { get; set; } = "";
-        public string? PlexName { get; set; }
-    }
+    public string DiscordId { get; set; } = "";
+    public string? PlexName { get; set; }
 }

--- a/src/PlexNotifierr.Api/Models/UnsubscribeRequest.cs
+++ b/src/PlexNotifierr.Api/Models/UnsubscribeRequest.cs
@@ -1,7 +1,6 @@
-namespace PlexNotifierr.Api.Models
+namespace PlexNotifierr.Api.Models;
+
+public class UnsubscribeRequest
 {
-    public class UnsubscribeRequest
-    {
-        public string DiscordId { get; set; } = "";
-    }
+    public string DiscordId { get; set; } = "";
 }

--- a/src/PlexNotifierr.Api/PlexNotifierr.Api.csproj
+++ b/src/PlexNotifierr.Api/PlexNotifierr.Api.csproj
@@ -1,21 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire" Version="1.8.6" />
+    <PackageReference Include="Hangfire" Version="1.8.21" />
     <PackageReference Include="Hangfire.Console.Extensions" Version="1.1.0" />
     <PackageReference Include="Hangfire.Heartbeat" Version="0.6.0" />
     <PackageReference Include="Hangfire.Storage.SQLite" Version="0.4.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.20">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlexNotifierr.Api/Program.cs
+++ b/src/PlexNotifierr.Api/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using PlexNotifierr.Core.Models;
+using Scalar.AspNetCore;
 using Serilog;
 using static PlexNotifierr.Api.Extensions.HangfireExtensions;
 using static PlexNotifierr.Api.Extensions.PlexExtensions;
@@ -31,16 +32,14 @@ AddHangfire(builder.Services, configFile);
 AddHangfireServer(builder.Services, configFile);
 AddHangfireConsoleExtensions(builder.Services);
 
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddOpenApi();
 
 var app = builder.Build();
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.MapOpenApi();
+    app.MapScalarApiReference();
 }
 
 app.UseRouting();

--- a/src/PlexNotifierr.Core/Config/PlexConfig.cs
+++ b/src/PlexNotifierr.Core/Config/PlexConfig.cs
@@ -1,15 +1,14 @@
-﻿namespace PlexNotifierr.Core.Config
+namespace PlexNotifierr.Core.Config;
+
+public class PlexConfig
 {
-    public class PlexConfig
-    {
-        public string? Product { get; set; }
+    public string? Product { get; set; }
 
-        public string? DeviceName { get; set; }
+    public string? DeviceName { get; set; }
 
-        public string? ClientId { get; set; }
+    public string? ClientId { get; set; }
 
-        public string ServerUrl { get; set; } = String.Empty;
+    public string ServerUrl { get; set; } = String.Empty;
 
-        public string AccessToken { get; set; } = String.Empty;
-    }
+    public string AccessToken { get; set; } = String.Empty;
 }

--- a/src/PlexNotifierr.Core/Messaging/INotificationSender.cs
+++ b/src/PlexNotifierr.Core/Messaging/INotificationSender.cs
@@ -1,10 +1,9 @@
 using Plex.ServerApi.PlexModels.Media;
 using PlexNotifierr.Core.Models;
 
-namespace PlexNotifierr.Core.Messaging
+namespace PlexNotifierr.Core.Messaging;
+
+public interface INotificationSender
 {
-    public interface INotificationSender
-    {
-        public bool TrySendMessage(string discordId, Media media, Metadata episode);
-    }
+    Task<bool> TrySendMessageAsync(string discordId, Media media, Metadata episode, CancellationToken cancellationToken = default);
 }

--- a/src/PlexNotifierr.Core/Messaging/NotificationSender.cs
+++ b/src/PlexNotifierr.Core/Messaging/NotificationSender.cs
@@ -7,83 +7,97 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 
-namespace PlexNotifierr.Core.Messaging
+namespace PlexNotifierr.Core.Messaging;
+
+public sealed class NotificationSender : INotificationSender, IAsyncDisposable
 {
-    public class NotificationSender : INotificationSender
+    private readonly RabbitMqConfig _config;
+    private readonly ILogger _logger;
+    private readonly SemaphoreSlim _connectionLock = new(1, 1);
+    private IConnection? _connection;
+
+    public NotificationSender(IOptions<RabbitMqConfig> options, ILogger<NotificationSender> logger)
     {
-        private readonly string _hostName;
-        private readonly string _userName;
-        private readonly string _password;
-        private readonly int _port;
-        private readonly string _virtualHost;
-        private IConnection? _connection;
-        private readonly ILogger _logger;
+        _config = options.Value;
+        _logger = logger;
+    }
 
-        public NotificationSender(IOptions<RabbitMqConfig> options, ILogger<NotificationSender> logger)
+    public async Task<bool> TrySendMessageAsync(string discordId, Media media, Metadata episode, CancellationToken cancellationToken = default)
+    {
+        try
         {
-            _hostName = options.Value.HostName;
-            _userName = options.Value.UserName;
-            _password = options.Value.Password;
-            _port = options.Value.Port;
-            _virtualHost = options.Value.VirtualHost;
-            _logger = logger;
+            var connection = await EnsureConnectionAsync(cancellationToken);
+            if (connection is null) return false;
 
-            CreateConnection();
+            await using var channel = await connection.CreateChannelAsync(cancellationToken: cancellationToken);
+            await channel.QueueDeclareAsync("discord", durable: true, exclusive: false, autoDelete: false, arguments: null, cancellationToken: cancellationToken);
+
+            var serializerOptions = new JsonSerializerOptions
+            {
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                WriteIndented = true
+            };
+            var props = new BasicProperties
+            {
+                ContentType = "application/json; charset=UTF-8"
+            };
+            var messageJson = JsonSerializer.Serialize(new { discordId, media.Title, episode.Summary, media.ThumbUrl, Season = episode.ParentIndex, Episode = episode.Index, EpisodeTitle = episode.Title, GrandParentRatingKey = episode.GrandparentKey }, serializerOptions);
+            var messageBytes = Encoding.UTF8.GetBytes(messageJson);
+
+            await channel.BasicPublishAsync(exchange: "", routingKey: "discord", mandatory: true, basicProperties: props, body: messageBytes, cancellationToken: cancellationToken);
+            _logger.LogDebug("Message sent successfully to RBMQ for user {DiscordId} on show {MediaTitle}", discordId, media.Title);
+            return true;
         }
-
-        public bool TrySendMessage(string discordId, Media media, Metadata episode)
+        catch (Exception e)
         {
-            try
-            {
-                if (!ConnectionExists()) return false;
-                using var channel = _connection!.CreateModel();
-                channel.QueueDeclare("discord", true, false, false, null);
-                var options = new JsonSerializerOptions
-                {
-                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-                    WriteIndented = true
-                };
-                var props = channel.CreateBasicProperties();
-                props.ContentType = "application/json; charset=UTF-8";
-                var messageJson = JsonSerializer.Serialize(new { discordId, media.Title, episode.Summary, media.ThumbUrl, Season = episode.ParentIndex, Episode = episode.Index, EpisodeTitle = episode.Title, GrandParentRatingKey = episode.GrandparentKey }, options);
-                var messageBytes = Encoding.UTF8.GetBytes(messageJson);
-                channel.BasicPublish("", "discord", true, props, messageBytes);
-                _logger.LogDebug("Message sent successfully to RBMQ for user {0} on show {1}", discordId, media.Title);
-                return true;
-            }
-            catch (Exception e)
-            {
-                _logger.LogError("Error while publishing message to {DiscordId} on show {MediaTitle} {EMessage}", discordId, media.Title, e.Message);
-                return false;
-            }
+            _logger.LogError(e, "Error while publishing message to {DiscordId} on show {MediaTitle}", discordId, media.Title);
+            return false;
         }
+    }
 
-        private void CreateConnection()
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection is not null)
         {
-            try
-            {
-                var factory = new ConnectionFactory()
-                {
-                    HostName = _hostName,
-                    UserName = _userName,
-                    Password = _password,
-                    Port = _port,
-                    VirtualHost = _virtualHost
-                };
-                _connection = factory.CreateConnection();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
-                throw;
-            }
+            await _connection.DisposeAsync();
+            _connection = null;
         }
+        _connectionLock.Dispose();
+    }
 
-        private bool ConnectionExists()
+    private async Task<IConnection?> EnsureConnectionAsync(CancellationToken cancellationToken)
+    {
+        if (_connection is { IsOpen: true }) return _connection;
+
+        await _connectionLock.WaitAsync(cancellationToken);
+        try
         {
-            if (_connection != null) return true;
-            CreateConnection();
-            return _connection != null;
+            if (_connection is { IsOpen: true }) return _connection;
+            if (_connection is not null)
+            {
+                await _connection.DisposeAsync();
+                _connection = null;
+            }
+
+            var factory = new ConnectionFactory
+            {
+                HostName = _config.HostName,
+                UserName = _config.UserName,
+                Password = _config.Password,
+                Port = _config.Port,
+                VirtualHost = _config.VirtualHost
+            };
+            _connection = await factory.CreateConnectionAsync(cancellationToken);
+            return _connection;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Failed to open RabbitMQ connection to {HostName}:{Port}", _config.HostName, _config.Port);
+            return null;
+        }
+        finally
+        {
+            _connectionLock.Release();
         }
     }
 }

--- a/src/PlexNotifierr.Core/Messaging/RabbitMqConfig.cs
+++ b/src/PlexNotifierr.Core/Messaging/RabbitMqConfig.cs
@@ -1,15 +1,14 @@
-namespace PlexNotifierr.Core.Messaging
+namespace PlexNotifierr.Core.Messaging;
+
+public class RabbitMqConfig
 {
-    public class RabbitMqConfig
-    {
-        public string HostName { get; set; } = String.Empty;
+    public string HostName { get; set; } = String.Empty;
 
-        public string UserName { get; set; } = String.Empty;
+    public string UserName { get; set; } = String.Empty;
 
-        public string Password { get; set; } = String.Empty;
+    public string Password { get; set; } = String.Empty;
 
-        public int Port { get; set; }
+    public int Port { get; set; }
 
-        public string VirtualHost { get; set; } = String.Empty;
-    }
+    public string VirtualHost { get; set; } = String.Empty;
 }

--- a/src/PlexNotifierr.Core/Models/Media.cs
+++ b/src/PlexNotifierr.Core/Models/Media.cs
@@ -1,28 +1,27 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace PlexNotifierr.Core.Models
+namespace PlexNotifierr.Core.Models;
+
+[Table("medias")]
+public class Media
 {
-    [Table("medias")]
-    public class Media
-    {
-        [Key]
-        [DatabaseGenerated(DatabaseGeneratedOption.None)]
-        [Column("rating_key")]
-        public int RatingKey { get; set; }
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    [Column("rating_key")]
+    public int RatingKey { get; set; }
 
-        [Column("title")]
-        public string Title { get; set; } = "";
+    [Column("title")]
+    public string Title { get; set; } = "";
 
-        [Column("summary")]
-        public string Summary { get; set; } = "";
+    [Column("summary")]
+    public string Summary { get; set; } = "";
 
-        [Column("thumb")]
-        public string ThumbUrl { get; set; } = "";
+    [Column("thumb")]
+    public string ThumbUrl { get; set; } = "";
 
-        [Column("last_notified")]
-        public DateTime LastNotified { get; set; } = DateTime.MinValue;
+    [Column("last_notified")]
+    public DateTime LastNotified { get; set; } = DateTime.MinValue;
 
-        public ICollection<UserSubscription> Users { get; set; } = new List<UserSubscription>();
-    }
+    public ICollection<UserSubscription> Users { get; set; } = new List<UserSubscription>();
 }

--- a/src/PlexNotifierr.Core/Models/MediaType.cs
+++ b/src/PlexNotifierr.Core/Models/MediaType.cs
@@ -1,19 +1,17 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
-namespace PlexNotifierr.Core.Models
+namespace PlexNotifierr.Core.Models;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum MediaType
 {
+    [EnumMember(Value = "Show")]
+    Show = 0,
 
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public enum MediaType
-    {
-        [EnumMember(Value = "Show")]
-        Show = 0,
+    [EnumMember(Value = "Season")]
+    Season = 1,
 
-        [EnumMember(Value = "Season")]
-        Season = 1,
-
-        [EnumMember(Value = "Episode")]
-        Episode = 2,
-    }
+    [EnumMember(Value = "Episode")]
+    Episode = 2,
 }

--- a/src/PlexNotifierr.Core/Models/PlexNotifierrDbContext.cs
+++ b/src/PlexNotifierr.Core/Models/PlexNotifierrDbContext.cs
@@ -1,38 +1,37 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 
-namespace PlexNotifierr.Core.Models
+namespace PlexNotifierr.Core.Models;
+
+public sealed class PlexNotifierrDbContext : DbContext
 {
-    public sealed class PlexNotifierrDbContext : DbContext
+    public PlexNotifierrDbContext()
     {
-        public PlexNotifierrDbContext()
-        {
-            Database.EnsureCreated();
-            ChangeTracker.LazyLoadingEnabled = false;
-        }
-
-        public PlexNotifierrDbContext(DbContextOptions<PlexNotifierrDbContext> options) : base(options)
-        {
-            Database.EnsureCreated();
-            ChangeTracker.LazyLoadingEnabled = false;
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-
-            UserSubscription.OnModelCreating(modelBuilder);
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder options)
-        {
-            if (options.IsConfigured == false)
-                options.UseSqlite("PlexNotifierr.db");
-        }
-
-        public DbSet<Media> Medias => Set<Media>();
-
-        public DbSet<User> Users => Set<User>();
-
-        public DbSet<UserSubscription> UserSubscriptions => Set<UserSubscription>();
+        Database.EnsureCreated();
+        ChangeTracker.LazyLoadingEnabled = false;
     }
+
+    public PlexNotifierrDbContext(DbContextOptions<PlexNotifierrDbContext> options) : base(options)
+    {
+        Database.EnsureCreated();
+        ChangeTracker.LazyLoadingEnabled = false;
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        UserSubscription.OnModelCreating(modelBuilder);
+    }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options)
+    {
+        if (options.IsConfigured == false)
+            options.UseSqlite("PlexNotifierr.db");
+    }
+
+    public DbSet<Media> Medias => Set<Media>();
+
+    public DbSet<User> Users => Set<User>();
+
+    public DbSet<UserSubscription> UserSubscriptions => Set<UserSubscription>();
 }

--- a/src/PlexNotifierr.Core/Models/User.cs
+++ b/src/PlexNotifierr.Core/Models/User.cs
@@ -1,31 +1,30 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace PlexNotifierr.Core.Models
+namespace PlexNotifierr.Core.Models;
+
+[Table("users")]
+public class User
 {
-    [Table("users")]
-    public class User
-    {
-        [Key]
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        [Column("id")]
-        public Guid Id { get; set; }
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    [Column("id")]
+    public Guid Id { get; set; }
 
-        [Column("plex_id")]
-        public int PlexId { get; set; }
+    [Column("plex_id")]
+    public int PlexId { get; set; }
 
-        [Column("plex_name")]
-        public string PlexName { get; set; } = "";
+    [Column("plex_name")]
+    public string PlexName { get; set; } = "";
 
-        [Column("active")]
-        public bool Active { get; set; }
+    [Column("active")]
+    public bool Active { get; set; }
 
-        [Column("discord_id")]
-        public string? DiscordId { get; set; }
+    [Column("discord_id")]
+    public string? DiscordId { get; set; }
 
-        [Column("history_position")]
-        public int HistoryPosition { get; set; } = 0;
+    [Column("history_position")]
+    public int HistoryPosition { get; set; } = 0;
 
-        public ICollection<UserSubscription> Medias { get; set; } = new List<UserSubscription>();
-    }
+    public ICollection<UserSubscription> Medias { get; set; } = new List<UserSubscription>();
 }

--- a/src/PlexNotifierr.Core/Models/UserSubscription.cs
+++ b/src/PlexNotifierr.Core/Models/UserSubscription.cs
@@ -1,38 +1,37 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace PlexNotifierr.Core.Models
+namespace PlexNotifierr.Core.Models;
+
+[Table("user_subscriptions")]
+public class UserSubscription
 {
-    [Table("user_subscriptions")]
-    public class UserSubscription
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Column("rating_key")]
+    public int RatingKey { get; set; }
+
+    [Column("active")]
+    public bool Active { get; set; }
+
+    public User User { get; set; } = null!;
+
+    public Media Media { get; set; } = null!;
+
+    public static void OnModelCreating(ModelBuilder modelBuilder)
     {
-        [Column("user_id")]
-        public Guid UserId { get; set; }
+        _ = modelBuilder.Entity<UserSubscription>()
+                    .HasKey(us => new { us.UserId, us.RatingKey });
 
-        [Column("rating_key")]
-        public int RatingKey { get; set; }
+        _ = modelBuilder.Entity<UserSubscription>()
+                        .HasOne(us => us.User)
+                        .WithMany(u => u.Medias)
+                        .HasForeignKey(us => us.UserId);
 
-        [Column("active")]
-        public bool Active { get; set; }
-
-        public User User { get; set; } = null!;
-
-        public Media Media { get; set; } = null!;
-
-        public static void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            _ = modelBuilder.Entity<UserSubscription>()
-                        .HasKey(us => new { us.UserId, us.RatingKey });
-
-            _ = modelBuilder.Entity<UserSubscription>()
-                            .HasOne(us => us.User)
-                            .WithMany(u => u.Medias)
-                            .HasForeignKey(us => us.UserId);
-
-            _ = modelBuilder.Entity<UserSubscription>()
-                            .HasOne(us => us.Media)
-                            .WithMany(m => m.Users)
-                            .HasForeignKey(m => m.RatingKey);
-        }
+        _ = modelBuilder.Entity<UserSubscription>()
+                        .HasOne(us => us.Media)
+                        .WithMany(m => m.Users)
+                        .HasForeignKey(m => m.RatingKey);
     }
 }

--- a/src/PlexNotifierr.Core/PlexNotifierr.Core.csproj
+++ b/src/PlexNotifierr.Core/PlexNotifierr.Core.csproj
@@ -1,27 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.20" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.20">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.20" />
-    <PackageReference Include="Serilog" Version="3.1.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="Plex.Api" Version="4.1.2" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/PlexNotifierr.Worker/Jobs/GetRecentlyAddedJob.cs
+++ b/src/PlexNotifierr.Worker/Jobs/GetRecentlyAddedJob.cs
@@ -11,70 +11,66 @@ using PlexNotifierr.Core.Config;
 using PlexNotifierr.Core.Messaging;
 using PlexNotifierr.Core.Models;
 
-namespace PlexNotifierr.Worker.Jobs
+namespace PlexNotifierr.Worker.Jobs;
+
+public class GetRecentlyAddedJob
 {
-    /// <summary>
-    /// A job to get recently added episode of show and notify user.
-    /// </summary>
-    public class GetRecentlyAddedJob
+    private readonly PlexNotifierrDbContext _dbContext;
+    private readonly IPlexServerClient _serverClient;
+    private readonly INotificationSender _notificationSender;
+    private readonly IProgressBarFactory _progressBarFactory;
+    private readonly string _url;
+    private readonly string _authToken;
+    private readonly ILogger _logger;
+
+
+    public GetRecentlyAddedJob(PlexNotifierrDbContext dbContext, IPlexServerClient plexServerClient, INotificationSender notificationSender, IProgressBarFactory progressBarFactory, IOptions<PlexConfig> plexConfig, ILogger<GetUsersJob> logger)
     {
-        private readonly PlexNotifierrDbContext _dbContext;
-        private readonly IPlexServerClient _serverClient;
-        private readonly INotificationSender _notificationSender;
-        private readonly IProgressBarFactory _progressBarFactory;
-        private readonly string _url;
-        private readonly string _authToken;
-        private readonly ILogger _logger;
+        _dbContext = dbContext;
+        _serverClient = plexServerClient;
+        _notificationSender = notificationSender;
+        _progressBarFactory = progressBarFactory;
+        _url = plexConfig.Value.ServerUrl;
+        _authToken = plexConfig.Value.AccessToken;
+        _logger = logger;
+    }
 
-
-        public GetRecentlyAddedJob(PlexNotifierrDbContext dbContext, IPlexServerClient plexServerClient, INotificationSender notificationSender, IProgressBarFactory progressBarFactory, IOptions<PlexConfig> plexConfig, ILogger<GetUsersJob> logger)
+    [JobDisplayName("GetRecentlyAdded")]
+    public async Task ExecuteAsync()
+    {
+        var libraries = await _serverClient.GetLibrariesAsync(_authToken, _url);
+        _logger.LogInformation("{LibrariesCount} to process", libraries.Libraries.Count);
+        foreach (var library in libraries.Libraries.Where(library => library.Type == "show").ToList())
         {
-            _dbContext = dbContext;
-            _serverClient = plexServerClient;
-            _notificationSender = notificationSender;
-            _progressBarFactory = progressBarFactory;
-            _url = plexConfig.Value.ServerUrl;
-            _authToken = plexConfig.Value.AccessToken;
-            _logger = logger;
-        }
-
-        [JobDisplayName("GetRecentlyAdded")]
-        public async Task ExecuteAsync()
-        {
-            var libraries = await _serverClient.GetLibrariesAsync(_authToken, _url);
-            _logger.LogInformation("{LibrariesCount} to process", libraries.Libraries.Count);
-            foreach (var library in libraries.Libraries.Where(library => library.Type == "show").ToList())
+            _logger.LogInformation("Start library {LibraryTitle}", library.Title);
+            var progressBar = _progressBarFactory.Create();
+            var recentlyAddedEpisodes = await _serverClient.GetLibraryRecentlyAddedAsync(_authToken, _url, SearchType.Episode, library.Key, 0, 100);
+            if (recentlyAddedEpisodes?.Media is null) continue;
+            foreach (var recentlyAddedShow in recentlyAddedEpisodes.Media.GroupBy(x => x.GrandparentRatingKey)
+                                                                   .Select(x => new
+                                                                    {
+                                                                        RatingKey = x.Key,
+                                                                        LastEpisode = x.MaxBy(y => y.OriginallyAvailableAt),
+                                                                    }).ToList().WithProgress(progressBar))
             {
-                _logger.LogInformation("Start library {LibraryTitle}", library.Title);
-                var progressBar = _progressBarFactory.Create();
-                var recentlyAddedEpisodes = await _serverClient.GetLibraryRecentlyAddedAsync(_authToken, _url, SearchType.Episode, library.Key, 0, 100);
-                if (recentlyAddedEpisodes?.Media is null) continue;
-                foreach (var recentlyAddedShow in recentlyAddedEpisodes.Media.GroupBy(x => x.GrandparentRatingKey)
-                                                                       .Select(x => new
-                                                                        {
-                                                                            RatingKey = x.Key,
-                                                                            LastEpisode = x.MaxBy(y => y.OriginallyAvailableAt),
-                                                                        }).ToList().WithProgress(progressBar))
+                if (!DateTime.TryParse(recentlyAddedShow.LastEpisode?.OriginallyAvailableAt, out var originallyAvailableAt)
+                    || !int.TryParse(recentlyAddedShow.RatingKey, out var grandParentRatingKey)) continue;
+                var show = _dbContext.Medias.Include(x => x.Users).ThenInclude(y => y.User).FirstOrDefault(x => x.RatingKey == grandParentRatingKey);
+                var addedAt = new DateTime(1970, 1, 1, 0, 0, 0, 0).AddSeconds(recentlyAddedShow.LastEpisode.AddedAt).ToUniversalTime();
+                var minDateShow = new DateTime(Math.Min(originallyAvailableAt.Ticks, addedAt.Ticks));
+                if (show is null || minDateShow < show.LastNotified) continue;
+                var users = show.Users.Where(x => x.User.Active).Select(x => x.User);
+                var success = true;
+                foreach (var user in users)
                 {
-                    if (!DateTime.TryParse(recentlyAddedShow.LastEpisode?.OriginallyAvailableAt, out var originallyAvailableAt)
-                        || !int.TryParse(recentlyAddedShow.RatingKey, out var grandParentRatingKey)) continue;
-                    var show = _dbContext.Medias.Include(x => x.Users).ThenInclude(y => y.User).FirstOrDefault(x => x.RatingKey == grandParentRatingKey);
-                    var addedAt = new DateTime(1970, 1, 1, 0, 0, 0, 0).AddSeconds(recentlyAddedShow.LastEpisode.AddedAt).ToUniversalTime();
-                    var minDateShow = new DateTime(Math.Min(originallyAvailableAt.Ticks, addedAt.Ticks));
-                    if (show is null || minDateShow < show.LastNotified) continue;
-                    var users = show.Users.Where(x => x.User.Active).Select(x => x.User);
-                    var success = true;
-                    foreach (var user in users)
-                    {
-                        if (user.DiscordId is null) continue;
-                        _logger.LogInformation("Notification send for user {UserPlexName} on show {ShowTitle}", user.PlexName, show.Title);
-                        var successfulSend = _notificationSender.TrySendMessage(user.DiscordId, show, recentlyAddedShow.LastEpisode);
-                        if (success && !successfulSend) success = false;
-                    }
-                    if (success) show.LastNotified = DateTime.Now;
+                    if (user.DiscordId is null) continue;
+                    _logger.LogInformation("Notification send for user {UserPlexName} on show {ShowTitle}", user.PlexName, show.Title);
+                    var successfulSend = await _notificationSender.TrySendMessageAsync(user.DiscordId, show, recentlyAddedShow.LastEpisode);
+                    if (success && !successfulSend) success = false;
                 }
-                await _dbContext.SaveChangesAsync();
+                if (success) show.LastNotified = DateTime.Now;
             }
+            await _dbContext.SaveChangesAsync();
         }
     }
 }

--- a/src/PlexNotifierr.Worker/Jobs/GetUsersHistoryJob.cs
+++ b/src/PlexNotifierr.Worker/Jobs/GetUsersHistoryJob.cs
@@ -1,4 +1,4 @@
-﻿using Hangfire;
+using Hangfire;
 using Hangfire.Console;
 using Hangfire.Console.Extensions;
 using Hangfire.Server;
@@ -9,91 +9,87 @@ using Plex.ServerApi.Clients.Interfaces;
 using PlexNotifierr.Core.Config;
 using PlexNotifierr.Core.Models;
 
-namespace PlexNotifierr.Worker.Jobs
+namespace PlexNotifierr.Worker.Jobs;
+
+public class GetUsersHistoryJob
 {
-    /// <summary>
-    /// A job to get history of all the user.
-    /// </summary>
-    public class GetUsersHistoryJob
+    private readonly PlexNotifierrDbContext _dbContext;
+    private readonly IPlexServerClient _serverClient;
+    private readonly IProgressBarFactory _progressBarFactory;
+    private readonly string _url;
+    private readonly string _authToken;
+    private readonly ILogger _logger;
+
+    public GetUsersHistoryJob(PlexNotifierrDbContext dbContext, IPlexServerClient plexServerClient, IProgressBarFactory progressBarFactory, IOptions<PlexConfig> plexConfig, ILogger<GetUsersHistoryJob> logger)
     {
-        private readonly PlexNotifierrDbContext _dbContext;
-        private readonly IPlexServerClient _serverClient;
-        private readonly IProgressBarFactory _progressBarFactory;
-        private readonly string _url;
-        private readonly string _authToken;
-        private readonly ILogger _logger;
+        _dbContext = dbContext;
+        _serverClient = plexServerClient;
+        _progressBarFactory = progressBarFactory;
+        _url = plexConfig.Value.ServerUrl;
+        _authToken = plexConfig.Value.AccessToken;
+        _logger = logger;
+    }
 
-        public GetUsersHistoryJob(PlexNotifierrDbContext dbContext, IPlexServerClient plexServerClient, IProgressBarFactory progressBarFactory, IOptions<PlexConfig> plexConfig, ILogger<GetUsersHistoryJob> logger)
+    [JobDisplayName("GetUsersHistory")]
+    public async Task ExecuteAsync()
+    {
+        var users = await _dbContext.Users.Include(u => u.Medias).Include(us => us.Medias).ToListAsync();
+        var mediasRatingKey = _dbContext.Medias.Select(m => m.RatingKey).ToHashSet();
+
+        const int limit = 300;
+        _logger.LogInformation("{UsersCount} users to process", users.Count);
+        var progressBar = _progressBarFactory.Create();
+        foreach (var user in users.WithProgress(progressBar))
         {
-            _dbContext = dbContext;
-            _serverClient = plexServerClient;
-            _progressBarFactory = progressBarFactory;
-            _url = plexConfig.Value.ServerUrl;
-            _authToken = plexConfig.Value.AccessToken;
-            _logger = logger;
-        }
-
-        [JobDisplayName("GetUsersHistory")]
-        public async Task ExecuteAsync()
-        {
-            var users = await _dbContext.Users.Include(u => u.Medias).Include(us => us.Medias).ToListAsync();
-            var mediasRatingKey = _dbContext.Medias.Select(m => m.RatingKey).ToHashSet();
-
-            const int limit = 300;
-            _logger.LogInformation("{UsersCount} users to process", users.Count);
-            var progressBar = _progressBarFactory.Create();
-            foreach (var user in users.WithProgress(progressBar))
+            var offset = user.HistoryPosition;
+            var isLastPage = false;
+            while (!isLastPage)
             {
-                var offset = user.HistoryPosition;
-                var isLastPage = false;
-                while (!isLastPage)
+                try
                 {
-                    try
+                    var history = await _serverClient.GetPlayHistory(_authToken, _url, offset, limit, accountId: user.PlexId);
+                    isLastPage = history.Size < limit;
+                    offset += limit;
+                    if (history.HistoryMetadata is null) continue;
+                    foreach (var historyMetadata in history.HistoryMetadata.Where(historyMetadata => historyMetadata?.Type == "episode"))
                     {
-                        var history = await _serverClient.GetPlayHistory(_authToken, _url, offset, limit, accountId: user.PlexId);
-                        isLastPage = history.Size < limit;
-                        offset += limit;
-                        if (history.HistoryMetadata is null) continue;
-                        foreach (var historyMetadata in history.HistoryMetadata.Where(historyMetadata => historyMetadata?.Type == "episode"))
+                        var grandparentKey = historyMetadata.GrandParentKey;
+                        var grandparentRatingKey = grandparentKey?.Split('/').LastOrDefault() ?? string.Empty;
+                        if (!int.TryParse(grandparentRatingKey, out var grandParentRatingKey)) continue;
+                        if (!mediasRatingKey.Contains(grandParentRatingKey))
                         {
-                            var grandparentKey = historyMetadata.GrandParentKey;
-                            var grandparentRatingKey = grandparentKey?.Split('/').LastOrDefault() ?? string.Empty;
-                            if (!int.TryParse(grandparentRatingKey, out var grandParentRatingKey)) continue;
-                            if (!mediasRatingKey.Contains(grandParentRatingKey))
+                            var grandParentMediaContainer = await _serverClient.GetMediaMetadataAsync(_authToken, _url, grandparentRatingKey);
+                            var grandParentMetadata = grandParentMediaContainer.Media.FirstOrDefault();
+                            if (grandParentMetadata is null) continue;
+                            var posters = await _serverClient.GetMediaPostersAsync(_authToken, _url, grandparentRatingKey);
+                            var media = new Media()
                             {
-                                var grandParentMediaContainer = await _serverClient.GetMediaMetadataAsync(_authToken, _url, grandparentRatingKey);
-                                var grandParentMetadata = grandParentMediaContainer.Media.FirstOrDefault();
-                                if (grandParentMetadata is null) continue;
-                                var posters = await _serverClient.GetMediaPostersAsync(_authToken, _url, grandparentRatingKey);
-                                var media = new Media()
-                                {
-                                    RatingKey = grandParentRatingKey,
-                                    Title = grandParentMetadata.Title ?? "",
-                                    ThumbUrl = posters.Media.FirstOrDefault(x => !x.Key.StartsWith("/"))?.Key ?? "",
-                                    Summary = grandParentMetadata.Summary ?? "",
-                                };
-                                _dbContext.Add(media);
-                                mediasRatingKey.Add(grandParentRatingKey);
-                                _dbContext.UserSubscriptions.Add(new UserSubscription() { Media = media, User = user });
-                                _logger.LogInformation("New media {MediaTitle} added", media.Title);
-                            }
-                            else
-                            {
-                                var userSubscription = user.Medias.FirstOrDefault(x => x.RatingKey == grandParentRatingKey);
-                                if (userSubscription is not null) continue;
-                                var media = _dbContext.Medias.FirstOrDefault(x => x.RatingKey == grandParentRatingKey);
-                                if (media is null) continue;
-                                _dbContext.UserSubscriptions.Add(new UserSubscription() { Media = media, User = user });
-                                _logger.LogInformation("New subscription from {UserPlexName} to {MediaTitle}", user.PlexName, media.Title);
-                            }
+                                RatingKey = grandParentRatingKey,
+                                Title = grandParentMetadata.Title ?? "",
+                                ThumbUrl = posters.Media.FirstOrDefault(x => !x.Key.StartsWith("/"))?.Key ?? "",
+                                Summary = grandParentMetadata.Summary ?? "",
+                            };
+                            _dbContext.Add(media);
+                            mediasRatingKey.Add(grandParentRatingKey);
+                            _dbContext.UserSubscriptions.Add(new UserSubscription() { Media = media, User = user });
+                            _logger.LogInformation("New media {MediaTitle} added", media.Title);
                         }
-                        user.HistoryPosition += history.Size;
-                        _ = await _dbContext.SaveChangesAsync();
+                        else
+                        {
+                            var userSubscription = user.Medias.FirstOrDefault(x => x.RatingKey == grandParentRatingKey);
+                            if (userSubscription is not null) continue;
+                            var media = _dbContext.Medias.FirstOrDefault(x => x.RatingKey == grandParentRatingKey);
+                            if (media is null) continue;
+                            _dbContext.UserSubscriptions.Add(new UserSubscription() { Media = media, User = user });
+                            _logger.LogInformation("New subscription from {UserPlexName} to {MediaTitle}", user.PlexName, media.Title);
+                        }
                     }
-                    catch (Exception e)
-                    {
-                        _logger.LogError(e.Message);
-                    }
+                    user.HistoryPosition += history.Size;
+                    _ = await _dbContext.SaveChangesAsync();
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e.Message);
                 }
             }
         }

--- a/src/PlexNotifierr.Worker/Jobs/GetUsersJob.cs
+++ b/src/PlexNotifierr.Worker/Jobs/GetUsersJob.cs
@@ -1,5 +1,6 @@
 using Hangfire;
 using Hangfire.Console;
+using Hangfire.Console.Extensions;
 using Hangfire.Server;
 using Microsoft.EntityFrameworkCore;
 using Plex.Library.ApiModels.Accounts;

--- a/src/PlexNotifierr.Worker/Jobs/GetUsersJob.cs
+++ b/src/PlexNotifierr.Worker/Jobs/GetUsersJob.cs
@@ -1,6 +1,5 @@
-﻿using Hangfire;
+using Hangfire;
 using Hangfire.Console;
-using Hangfire.Console.Extensions;
 using Hangfire.Server;
 using Microsoft.EntityFrameworkCore;
 using Plex.Library.ApiModels.Accounts;
@@ -10,62 +9,58 @@ using Microsoft.Extensions.Options;
 using Plex.Api.Factories;
 using PlexNotifierr.Core.Config;
 
-namespace PlexNotifierr.Worker.Jobs
+namespace PlexNotifierr.Worker.Jobs;
+
+public class GetUsersJob
 {
-    /// <summary>
-    /// A job to get all the friend of a Plex account.
-    /// </summary>
-    public class GetUsersJob
+    private readonly PlexAccount _account;
+    private readonly PlexNotifierrDbContext _dbContext;
+    private readonly IProgressBarFactory _progressBarFactory;
+    private readonly ILogger _logger;
+
+    public GetUsersJob(PlexNotifierrDbContext dbContext, IPlexFactory plexFactory, IProgressBarFactory progressBarFactory, IOptions<PlexConfig> plexConfig, ILogger<GetUsersJob> logger)
     {
-        private readonly PlexAccount _account;
-        private readonly PlexNotifierrDbContext _dbContext;
-        private readonly IProgressBarFactory _progressBarFactory;
-        private readonly ILogger _logger;
+        _dbContext = dbContext;
+        _progressBarFactory = progressBarFactory;
+        _account = plexFactory.GetPlexAccount(plexConfig.Value.AccessToken);
+        _logger = logger;
+    }
 
-        public GetUsersJob(PlexNotifierrDbContext dbContext, IPlexFactory plexFactory, IProgressBarFactory progressBarFactory, IOptions<PlexConfig> plexConfig, ILogger<GetUsersJob> logger)
+    [JobDisplayName("GetUsers")]
+    public async Task ExecuteAsync()
+    {
+        var users = await _account.Friends();
+        _logger.LogInformation("{UsersCount} users to proceed.", users.Count);
+        var usersDb = await _dbContext.Users.ToListAsync();
+        var ownerUser = usersDb.FirstOrDefault(u => u.PlexId == 1);
+        if (ownerUser == null)
         {
-            _dbContext = dbContext;
-            _progressBarFactory = progressBarFactory;
-            _account = plexFactory.GetPlexAccount(plexConfig.Value.AccessToken);
-            _logger = logger;
-        }
-
-        [JobDisplayName("GetUsers")]
-        public async Task ExecuteAsync()
-        {
-            var users = await _account.Friends();
-            _logger.LogInformation("{UsersCount} users to proceed.", users.Count);
-            var usersDb = await _dbContext.Users.ToListAsync();
-            var ownerUser = usersDb.FirstOrDefault(u => u.PlexId == 1);
-            if (ownerUser == null)
+            _ = await _dbContext.Users.AddAsync(new User()
             {
+                PlexId = 1,
+                PlexName = _account.Username,
+                Active = false,
+            });
+        }
+        var progressBar = _progressBarFactory.Create();
+        foreach (var user in users.WithProgress(progressBar))
+        {
+            var userDb = usersDb.FirstOrDefault(u => u.PlexId == user.Id);
+            if (userDb != null)
+            {
+                userDb.PlexName = user.Username;
+            }
+            else
+            {
+                _logger.LogInformation("New user {UserUsername} added to system", user.Username);
                 _ = await _dbContext.Users.AddAsync(new User()
                 {
-                    PlexId = 1,
-                    PlexName = _account.Username,
+                    PlexId = user.Id,
+                    PlexName = user.Username,
                     Active = false,
                 });
             }
-            var progressBar = _progressBarFactory.Create();
-            foreach (var user in users.WithProgress(progressBar))
-            {
-                var userDb = usersDb.FirstOrDefault(u => u.PlexId == user.Id);
-                if (userDb != null)
-                {
-                    userDb.PlexName = user.Username;
-                }
-                else
-                {
-                    _logger.LogInformation("New user {UserUsername} added to system", user.Username);
-                    _ = await _dbContext.Users.AddAsync(new User()
-                    {
-                        PlexId = user.Id,
-                        PlexName = user.Username,
-                        Active = false,
-                    });
-                }
-            }
-            await _dbContext.SaveChangesAsync();
         }
+        await _dbContext.SaveChangesAsync();
     }
 }

--- a/src/PlexNotifierr.Worker/PlexNotifierr.Worker.csproj
+++ b/src/PlexNotifierr.Worker/PlexNotifierr.Worker.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.Console" Version="1.4.2" />
+    <PackageReference Include="Hangfire.Console" Version="1.4.3" />
     <PackageReference Include="Hangfire.Console.Extensions.Serilog" Version="1.0.3" />
-    <PackageReference Include="Hangfire.Core" Version="1.8.6" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.21" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Target `net10.0` across all 3 projects; bump EF Core, Microsoft.Extensions.Hosting, and the Serilog suite to net10-compatible majors.
- Replace Swashbuckle.AspNetCore with `Scalar.AspNetCore` + the built-in `Microsoft.AspNetCore.OpenApi`. OpenAPI UI now served at `/scalar/v1` in Development, spec at `/openapi/v1.json`.
- Migrate RabbitMQ.Client `6.8.1` → `7.0.0`: `NotificationSender` rewritten around the async API (`CreateChannelAsync`, `BasicPublishAsync`, `new BasicProperties()`), with lazy connection init guarded by a `SemaphoreSlim`, `IAsyncDisposable`, and automatic reconnect on dropped connection. `INotificationSender.TrySendMessage` becomes `TrySendMessageAsync`; `GetRecentlyAddedJob` awaits accordingly.
- Add a `PRAGMA integrity_check` against the Hangfire SQLite database at startup and reset the `.db` / `-wal` / `-shm` / `-journal` files when it reports `database disk image is malformed`. This stops the endless `Hangfire.Storage.SQLite.SQLiteDistributedLock` cleanup error loop we saw in prod.
- Bump Hangfire / Hangfire.Core `1.8.6` → `1.8.21`, Hangfire.Console `1.4.2` → `1.4.3`.
- Convert all hand-written `.cs` files to file-scoped namespaces. EF Core migrations are intentionally left in block-scoped form so they stay consistent with what `dotnet ef migrations add` generates.
- Bump Dockerfile (`sdk:7.0`/`aspnet:7.0` → `sdk:10.0`/`aspnet:10.0`) and CI matrix (`7.0` → `10.0`).

## Test plan
- [ ] `dotnet restore && dotnet build -c Release` succeeds (CI workflow)
- [ ] Docker image builds from the new `mcr.microsoft.com/dotnet/sdk:10.0` base
- [ ] App starts; `/scalar/v1` renders the OpenAPI UI in Development
- [ ] Subscribe / Unsubscribe endpoints still work end-to-end against SQLite
- [ ] Recurring jobs run (`GetUsersJob`, `GetUsersHistoryJob`, `GetRecentlyAddedJob`) and Hangfire dashboard at `/dashboard` is reachable
- [ ] RabbitMQ message publish works against a live broker; verify async `NotificationSender` recovers after a broker restart
- [ ] Simulate a corrupted Hangfire SQLite file (e.g. truncate) and confirm it is detected + reset on next startup instead of looping `database disk image is malformed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)